### PR TITLE
Basic ops: create, list, and delete buckets; put object

### DIFF
--- a/package/aistore/client/const.py
+++ b/package/aistore/client/const.py
@@ -16,3 +16,10 @@ URL_PARAM_PROVIDER = "provider"
 # ETL Communicator types
 ETL_IO_COMM_TYPE = "io://"
 ETL_PUSH_COMM_TYPE = "hpush://"
+
+PROVIDER_AIS = "ais"
+PROVIDER_AMAZON = "aws"
+PROVIDER_GOOGLE = "gcp"
+PROVIDER_HTTP = "ht"
+PROVIDER_AZURE = "azure"
+PROVIDER_HDFS = "hdfs"

--- a/package/aistore/client/msg.py
+++ b/package/aistore/client/msg.py
@@ -31,7 +31,7 @@ class Bck2BckMsg:
 
 
 class ActionMsg:
-    def __init__(self, action, name, value) -> None:
+    def __init__(self, action, name="", value=None) -> None:
         self.action = action
         self.name = name
         self.value = value

--- a/package/tests/test_client.py
+++ b/package/tests/test_client.py
@@ -1,13 +1,53 @@
 import unittest
+import os
 from aistore.client.api import Client
+from aistore.client.msg import Bck
+from aistore.client.const import PROVIDER_AIS
 
-
-class TestStringMethods(unittest.TestCase):
-    def test_list_objects(self):
+class TestBasicOps(unittest.TestCase):
+    def test_bucket(self):
         client = Client('http://localhost:8080')
-        objects = client.list_objects('test')
-        self.assertEqual(objects, ['a', 'b', 'c'])
 
+        res = client.list_buckets(provider=PROVIDER_AIS)
+        count = len(res)
+        bck = Bck('test', PROVIDER_AIS)
+        res = client.create_bucket(bck)
+        self.assertEqual(res.status_code, 200)
+        res = client.list_buckets(provider=PROVIDER_AIS)
+        count_new = len(res)
+        self.assertEqual(count+1, count_new)
+
+        res = client.destroy_bucket(bck)
+        self.assertEqual(res.status_code, 200)
+
+    def test_put_get(self):
+        client = Client('http://localhost:8080')
+
+        res = client.list_buckets(provider=PROVIDER_AIS)
+        bck = Bck('test', PROVIDER_AIS)
+        res = client.create_bucket(bck)
+        self.assertEqual(res.status_code, 200)
+
+        tmpfile = "/tmp/py-sdk-test"
+        orig_cont = "test string"
+        with open(tmpfile, "w") as fdata:
+            fdata.write(orig_cont)
+
+        res = client.put_object(bck, "obj1", tmpfile)
+        os.remove(tmpfile)
+        self.assertEqual(res.status_code, 200)
+        res.close()
+
+        objects = client.list_objects(bck)
+        self.assertFalse(objects is None)
+
+        res = client.get_object(bck, "obj1")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content.decode("utf-8"), orig_cont)
+        res.close()
+
+        res = client.destroy_bucket(bck)
+        self.assertEqual(res.status_code, 200)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes:

- added create bucket
- added list buckets
- added destroy bucket
- added put object
- added a few constants
- changed get object
- changed test to show usage of functions above

New in the latest commit:

- Two last arguments of ActionMsg constructor have default values for easier using actions that require only action name
- create_bucket/destroy_bucket accept `Bck` instead of `string`